### PR TITLE
Refactor subir pedidos with single worker and step tracking

### DIFF
--- a/templates/subir_pedidos.html
+++ b/templates/subir_pedidos.html
@@ -4,15 +4,15 @@
 {% block content %}
 <div class="max-w-md mx-auto bg-white p-6 rounded-3xl shadow-xl space-y-4">
   <h1 class="text-2xl font-bold text-center">🚚 Subir Pedidos</h1>
-  <form id="cred-form" class="space-y-4">
+  <form id="cred-form" class="space-y-4" autocomplete="off">
     <div>
       <label class="block mb-1 font-medium">Usuario</label>
-      <input type="text" id="usuario" name="usuario"
+      <input name="usuario" id="usuario" type="text" required autocomplete="username"
              class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" />
     </div>
     <div>
       <label class="block mb-1 font-medium">Contraseña</label>
-      <input type="password" id="contrasena" name="contrasena"
+      <input name="contrasena" id="contrasena" type="password" required autocomplete="new-password"
              class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" />
     </div>
   </form>
@@ -29,6 +29,7 @@
         <th class="p-2">Ruta</th>
         <th class="p-2">Placa</th>
         <th class="p-2">Estado</th>
+        <th class="p-2">Paso actual</th>
         <th class="p-2">Acción</th>
       </tr>
     </thead>
@@ -38,6 +39,7 @@
         <td class="p-2">{{ v.ruta }}</td>
         <td class="p-2"><input type="text" maxlength="10" value="{{ v.placa }}" class="placa-input w-full border rounded p-1"/></td>
         <td class="p-2 estado">{{ v.estado }}</td>
+        <td class="p-2 paso">{{ v.paso or '' }}</td>
         <td class="p-2"><button class="play-btn px-3 py-1 bg-green-600 text-white rounded">Play</button></td>
       </tr>
     {% endfor %}
@@ -73,9 +75,11 @@ function attachRowEvents(tr){
       body: JSON.stringify({bd: bd, ruta: parseInt(tr.dataset.ruta), usuario: usuario, contrasena: contrasena})
     }).then(r=>r.json()).then(res=>{
       if(res.success){
-        tr.querySelector('.estado').textContent = 'ejecutando...';
+        tr.querySelector('.estado').textContent = res.data.status;
+        tr.querySelector('.paso').textContent = '';
       } else {
         tr.querySelector('.estado').textContent = 'error';
+        tr.querySelector('.paso').textContent = '';
       }
     });
   });
@@ -97,6 +101,7 @@ document.getElementById('btn-add').addEventListener('click', function(){
       tr.innerHTML = `<td class="p-2">${v.ruta}</td>
         <td class="p-2"><input type="text" maxlength="10" value="" class="placa-input w-full border rounded p-1"/></td>
         <td class="p-2 estado">pendiente</td>
+        <td class="p-2 paso"></td>
         <td class="p-2"><button class="play-btn px-3 py-1 bg-green-600 text-white rounded">Play</button></td>`;
       document.getElementById('tabla-vehiculos').appendChild(tr);
       attachRowEvents(tr);
@@ -111,6 +116,12 @@ function poll(){
       .then(r=>r.json()).then(res=>{
         if(res.success){
           tr.querySelector('.estado').textContent = res.data.status;
+          tr.querySelector('.paso').textContent = res.data.paso || '';
+          if(res.data.status === 'error'){
+            tr.querySelector('.estado').title = res.data.message || '';
+          } else {
+            tr.querySelector('.estado').removeAttribute('title');
+          }
         }
       });
   });

--- a/views/subir_pedidos.py
+++ b/views/subir_pedidos.py
@@ -1,18 +1,13 @@
 import os
 import json
+import queue
 import threading
-from concurrent.futures import ThreadPoolExecutor
+import pathlib
 from datetime import datetime
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 import pandas as pd
-from flask import (
-    Blueprint,
-    render_template,
-    request,
-    session,
-    jsonify,
-)
+from flask import Blueprint, render_template, request, session, jsonify
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
@@ -23,17 +18,59 @@ from db import conectar
 from views.auth import login_required
 
 # ---------------------------------------------------------------------------
-# Configuración global: executor y estados de jobs
+# Configuración global
 # ---------------------------------------------------------------------------
+
 subir_pedidos_bp = Blueprint("subir_pedidos", __name__, template_folder="../templates")
 
-_executor = ThreadPoolExecutor(max_workers=3)
+# worker de un solo hilo y cola FIFO
+_job_queue: "queue.Queue[Tuple[str, int, str, str]]" = queue.Queue()
 _states_lock = threading.Lock()
-_job_states: Dict[Tuple[str, int], Dict[str, str]] = {}
+_job_states: Dict[Tuple[str, int], Dict[str, Optional[str]]] = {}
+
+
+def _worker_loop() -> None:
+    while True:
+        bd, ruta, usuario, password = _job_queue.get()
+        with _states_lock:
+            st = _job_states.setdefault(
+                (bd, ruta),
+                {
+                    "status": "pendiente",
+                    "current_step": None,
+                    "started_at": "",
+                    "ended_at": "",
+                    "message": "",
+                    "failed_step": None,
+                },
+            )
+            st["status"] = "ejecutando"
+            st["started_at"] = datetime.utcnow().isoformat()
+        try:
+            subir_pedidos_ruta(bd, ruta, usuario, password)
+            with _states_lock:
+                st = _job_states[(bd, ruta)]
+                st["status"] = "exito"
+                st["ended_at"] = datetime.utcnow().isoformat()
+        except Exception as e:  # pragma: no cover - selenium/portal interaction
+            with _states_lock:
+                st = _job_states[(bd, ruta)]
+                st["status"] = "error"
+                st["message"] = str(e)
+                st["failed_step"] = st.get("current_step")
+                st["ended_at"] = datetime.utcnow().isoformat()
+        finally:
+            _job_queue.task_done()
+
+
+_worker_thread = threading.Thread(target=_worker_loop, daemon=True)
+_worker_thread.start()
+
 
 # ---------------------------------------------------------------------------
 # Helpers BD
 # ---------------------------------------------------------------------------
+
 
 def _ensure_table() -> None:
     """Crea la tabla vehiculos si no existe."""
@@ -61,6 +98,19 @@ def _get_bd() -> str:
     return bd
 
 
+def _obtener_placa(bd: str, ruta: int) -> str:
+    conn = conectar()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT placa FROM vehiculos WHERE bd=%s AND ruta=%s",
+        (bd, ruta),
+    )
+    row = cur.fetchone()
+    cur.close()
+    conn.close()
+    return row[0] if row else ""
+
+
 def _get_vehiculos(bd: str):
     conn = conectar()
     cur = conn.cursor()
@@ -80,7 +130,12 @@ def _get_vehiculos(bd: str):
         with _states_lock:
             st = _job_states.get((bd, r[0]), {})
         vehiculos.append(
-            {"ruta": r[0], "placa": r[1], "estado": st.get("status", "pendiente")}
+            {
+                "ruta": r[0],
+                "placa": r[1],
+                "estado": _status_text(st.get("status", "pendiente")),
+                "paso": st.get("current_step"),
+            }
         )
     return vehiculos
 
@@ -113,13 +168,96 @@ def _add_ruta(bd: str) -> Dict[str, int]:
     conn.commit()
     cur.close()
     conn.close()
-    return {"ruta": next_ruta, "placa": "", "estado": "pendiente"}
+    return {"ruta": next_ruta, "placa": "", "estado": "pendiente", "paso": None}
+
 
 # ---------------------------------------------------------------------------
-# Lógica Selenium reutilizada
+# Selenium config y helpers de estado
 # ---------------------------------------------------------------------------
 
-def subir_pedidos_ruta(bd: str, ruta: int, usuario: str, password: str) -> None:
+
+CONFIG = {
+    "modulo.url": "https://portal.gruponutresa.com/p/nuevo/pedido-masivo/excel",
+    "login.user": "#usuario",
+    "login.pass": "#password",
+    "login.submit": "#root > section > section > div.auth__layout-container-center.overflow-x-hidden.overflow-y-auto > div > div > form > button",
+    "login.ok": "#root > div > section > header > section > section > article.customer-header__my-business > section > button",
+    "modulo.ok": "#root > div > section > article > section > section > form > div > fieldset > article > div > div",
+    "carga.combo1": "#root > div > section > article > section > section > form > div > fieldset > article:nth-child(1) > div > div",
+    "carga.combo2": "#root > div > section > article > section > section > form > div > fieldset > article:nth-child(2) > div > div",
+    "carga.fileLabel": "#root > div > section > article > section > section > form > section > label > section.file-input__label-text",
+    "carga.fileInput": "form input[type='file']",
+    "carga.guardar": "#root > div > section > article > section > section > form > footer > button.MuiButtonBase-root.MuiButton-root.MuiButton-text.MuiButton-textPrimary.MuiButton-sizeMedium.MuiButton-textSizeMedium.MuiButton-root.MuiButton-text.MuiButton-textPrimary.MuiButton-sizeMedium.MuiButton-textSizeMedium.mb2.admin__create-footer-save.w5-ns.css-kp69xf",
+    "carga.continuar": "#root > div > section > article > section > article > footer > button:nth-child(3) > span.MuiButton-startIcon.MuiButton-iconSizeMedium.css-6xugel > svg",
+    "canal.input": "#purchaseOrderNN13CANALT",
+    "canal.value": "14",
+    "placa.input": "#formValue",
+    "carrito.confirmar": "#root > div > section > article > section > section > section.cart__resume-options > button:nth-child(3)",
+    "respuesta.aceptar": "#root > div > section > article > section > section > section > section.order__confirmation-products > article.order__confirmation-products-button > button",
+}
+
+
+def _status_text(status: str) -> str:
+    return {
+        "pendiente": "pendiente",
+        "en cola": "en cola",
+        "ejecutando": "ejecutando…",
+        "exito": "subido con éxito",
+        "error": "error",
+    }.get(status, status)
+
+
+def _set_state(bd: str, ruta: int, **kwargs) -> None:
+    with _states_lock:
+        st = _job_states.setdefault(
+            (bd, ruta),
+            {
+                "status": "pendiente",
+                "current_step": None,
+                "started_at": "",
+                "ended_at": "",
+                "message": "",
+                "failed_step": None,
+            },
+        )
+        st.update(kwargs)
+
+
+def _set_step(bd: str, ruta: int, step: Optional[str]) -> None:
+    _set_state(bd, ruta, current_step=step)
+
+
+def _current_step(bd: str, ruta: int) -> Optional[str]:
+    with _states_lock:
+        return _job_states.get((bd, ruta), {}).get("current_step")
+
+
+# ---------------------------------------------------------------------------
+# Funciones Selenium por paso
+# ---------------------------------------------------------------------------
+
+
+def build_driver() -> webdriver.Chrome:  # pragma: no cover - requiere driver
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    return webdriver.Chrome(options=options)
+
+
+def selenium_login(driver, config, usuario: str, password: str) -> None:
+    driver.get(config["modulo.url"])
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, config["login.user"]))
+    ).send_keys(usuario)
+    driver.find_element(By.CSS_SELECTOR, config["login.pass"]).send_keys(password)
+    driver.find_element(By.CSS_SELECTOR, config["login.submit"]).click()
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, config["login.ok"]))
+    )
+
+
+def selenium_crear_excel_pedidos(bd: str, ruta: int) -> pathlib.Path:
     conn = conectar()
     cur = conn.cursor()
     cur.execute("SELECT fn_obtener_pedidos_con_pedir_json(%s);", (bd,))
@@ -133,96 +271,134 @@ def subir_pedidos_ruta(bd: str, ruta: int, usuario: str, password: str) -> None:
 
     df = pd.DataFrame(registros)[["codigo_pro", "producto", "pedir"]]
     df.insert(2, "UN", "UN")
-    fichero = f"{ruta}.xlsx"
-    df.to_excel(
-        fichero,
-        sheet_name="Pedidos",
-        startrow=4,
-        index=False,
-        engine="openpyxl",
+    tmp = pathlib.Path(f"{ruta}.xlsx")
+    df.to_excel(tmp, sheet_name="Pedidos", startrow=4, index=False, engine="openpyxl")
+    return tmp
+
+
+def selenium_ir_modulo_carga(driver, config) -> None:
+    driver.get(config["modulo.url"])
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, config["modulo.ok"]))
     )
 
-    options = Options()
-    options.add_argument("--headless")
-    options.add_argument("--no-sandbox")
-    options.add_argument("--disable-dev-shm-usage")
-    driver = webdriver.Chrome(options=options)
 
-    driver.get("https://portal.gruponutresa.com/")
-    WebDriverWait(driver, 30).until(
-        EC.presence_of_element_located((By.NAME, "username"))
-    ).send_keys(usuario)
-    WebDriverWait(driver, 30).until(
-        EC.presence_of_element_located((By.NAME, "password"))
-    ).send_keys(password)
-    driver.find_element(By.CSS_SELECTOR, "form").submit()
-
-    driver.get("https://portal.gruponutresa.com/p/nuevo/pedido-masivo/excel")
-    file_input = WebDriverWait(driver, 30).until(
-        EC.presence_of_element_located((By.CSS_SELECTOR, 'input[type="file"]'))
-    )
-    file_input.send_keys(os.path.abspath(fichero))
-    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-
+def selenium_cargar_excel(driver, config, xls_path) -> None:
     try:
-        btn = WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "//button[contains(., 'Agregar al carrito')]") )
-        )
-        btn.click()
+        driver.find_element(By.CSS_SELECTOR, config["carga.combo1"]).click()
+        driver.find_element(By.CSS_SELECTOR, config["carga.combo2"]).click()
     except Exception:
         pass
+    file_input = driver.find_element(By.CSS_SELECTOR, config["carga.fileInput"])
+    file_input.send_keys(str(xls_path))
+    driver.find_element(By.CSS_SELECTOR, config["carga.guardar"]).click()
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, config["carga.continuar"]))
+    ).click()
 
+
+def selenium_set_canal(driver, config) -> None:
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, config["canal.input"]))
+    ).send_keys(config["canal.value"])
+
+
+def selenium_ir_carrito(driver, config) -> None:
     driver.get("https://portal.gruponutresa.com/carrito/resumen")
+
+
+def selenium_anotar_placas(driver, config, placa: str) -> None:
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, config["placa.input"]))
+    ).send_keys(placa)
+
+
+def selenium_confirmar_pedido(driver, config) -> None:
+    WebDriverWait(driver, 30).until(
+        EC.element_to_be_clickable((By.CSS_SELECTOR, config["carrito.confirmar"]))
+    ).click()
+
+
+def selenium_confirmar_respuesta(driver, config) -> Dict[str, str]:
     try:
         WebDriverWait(driver, 30).until(
-            EC.element_to_be_clickable(
-                (By.XPATH, "//button[contains(., 'Confirmar pedido')]")
-            )
+            EC.element_to_be_clickable((By.CSS_SELECTOR, config["respuesta.aceptar"]))
         ).click()
     except Exception:
         pass
+    return {"status": "ok"}
 
-    driver.quit()
-    os.remove(fichero)
+
+# ---------------------------------------------------------------------------
+# Orquestación
+# ---------------------------------------------------------------------------
+
+
+def subir_pedidos_ruta(bd: str, ruta: int, usuario: str, password: str) -> None:
+    _set_step(bd, ruta, "crear_excel")
+    xls = selenium_crear_excel_pedidos(bd, ruta)
+    driver = build_driver()
+    try:
+        _set_step(bd, ruta, "login")
+        selenium_login(driver, CONFIG, usuario, password)
+
+        _set_step(bd, ruta, "ir_modulo")
+        selenium_ir_modulo_carga(driver, CONFIG)
+
+        _set_step(bd, ruta, "cargar_excel")
+        selenium_cargar_excel(driver, CONFIG, xls)
+
+        _set_step(bd, ruta, "set_canal")
+        selenium_set_canal(driver, CONFIG)
+
+        _set_step(bd, ruta, "ir_carrito")
+        selenium_ir_carrito(driver, CONFIG)
+
+        placa = _obtener_placa(bd, ruta)
+        _set_step(bd, ruta, "anotar_placas")
+        selenium_anotar_placas(driver, CONFIG, placa)
+
+        _set_step(bd, ruta, "confirmar_pedido")
+        selenium_confirmar_pedido(driver, CONFIG)
+
+        _set_step(bd, ruta, "confirmar_respuesta")
+        res = selenium_confirmar_respuesta(driver, CONFIG)
+        _set_state(bd, ruta, message=json.dumps(res))
+    finally:  # pragma: no cover - cleanup
+        try:
+            driver.quit()
+        finally:
+            if xls.exists():
+                os.remove(xls)
+
 
 # ---------------------------------------------------------------------------
 # Gestión de jobs
 # ---------------------------------------------------------------------------
 
-def _job_runner(bd: str, ruta: int, usuario: str, password: str) -> None:
-    with _states_lock:
-        _job_states[(bd, ruta)] = {
-            "status": "ejecutando...",
-            "message": "",
-            "started_at": datetime.utcnow().isoformat(),
-            "ended_at": "",
-        }
-    try:
-        subir_pedidos_ruta(bd, ruta, usuario, password)
-        with _states_lock:
-            _job_states[(bd, ruta)]["status"] = "subido con éxito"
-            _job_states[(bd, ruta)]["ended_at"] = datetime.utcnow().isoformat()
-    except Exception as e:
-        with _states_lock:
-            _job_states[(bd, ruta)]["status"] = "error"
-            _job_states[(bd, ruta)]["message"] = str(e)
-            _job_states[(bd, ruta)]["ended_at"] = datetime.utcnow().isoformat()
 
-
-def _enqueue_job(bd: str, ruta: int, usuario: str, password: str) -> None:
+def _enqueue_job(bd: str, ruta: int, usuario: str, password: str) -> str:
     with _states_lock:
         st = _job_states.get((bd, ruta))
-        if st and st.get("status") == "ejecutando...":
-            return
-        _job_states.setdefault(
-            (bd, ruta),
-            {"status": "pendiente", "message": "", "started_at": "", "ended_at": ""},
-        )
-    _executor.submit(_job_runner, bd, ruta, usuario, password)
+        if st and st.get("status") in {"ejecutando", "en cola"}:
+            return _status_text(st["status"])
+        status = "ejecutando" if _job_queue.empty() else "en cola"
+        _job_states[(bd, ruta)] = {
+            "status": status,
+            "current_step": None,
+            "started_at": datetime.utcnow().isoformat() if status == "ejecutando" else "",
+            "ended_at": "",
+            "message": "",
+            "failed_step": None,
+        }
+    _job_queue.put((bd, ruta, usuario, password))
+    return _status_text(status)
+
 
 # ---------------------------------------------------------------------------
 # Rutas
 # ---------------------------------------------------------------------------
+
 
 @subir_pedidos_bp.route("/subir-pedidos", methods=["GET"])
 @login_required
@@ -265,10 +441,12 @@ def ejecutar_ruta():
         data = request.get_json() or {}
         bd = _get_bd()
         ruta = int(data.get("ruta"))
-        usuario = data.get("usuario", "")
-        password = data.get("contrasena", "")
-        _enqueue_job(bd, ruta, usuario, password)
-        return jsonify(success=True)
+        usuario = data.get("usuario")
+        password = data.get("contrasena")
+        if not usuario or not password:
+            return jsonify(success=False, error="Credenciales requeridas"), 400
+        status = _enqueue_job(bd, ruta, usuario, password)
+        return jsonify(success=True, data={"status": status})
     except Exception as e:
         return jsonify(success=False, error=str(e)), 400
 
@@ -279,5 +457,23 @@ def estado_ruta():
     bd = request.args.get("bd") or _get_bd()
     ruta = int(request.args.get("ruta", 0))
     with _states_lock:
-        st = _job_states.get((bd, ruta), {"status": "pendiente"})
-    return jsonify(success=True, data={"status": st.get("status"), "message": st.get("message", "")})
+        st = _job_states.get(
+            (bd, ruta),
+            {
+                "status": "pendiente",
+                "current_step": None,
+                "message": "",
+                "failed_step": None,
+            },
+        )
+    return jsonify(
+        success=True,
+        data={
+            "status": _status_text(st.get("status", "pendiente")),
+            "paso": st.get("current_step"),
+            "failed_step": st.get("failed_step"),
+            "message": st.get("message", ""),
+        },
+    )
+
+


### PR DESCRIPTION
## Summary
- Add single-threaded job queue with per-step state tracking for subir pedidos
- Split Selenium logic into granular step functions and update database-backed orchestration
- Improve UI: credential form without autofill, status/paso columns with polling

## Testing
- `python -m py_compile views/subir_pedidos.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689addbc57e8832d9c28a8de66f40696