### PR TITLE
Fix pool connection handling to return real connection

### DIFF
--- a/db.py
+++ b/db.py
@@ -25,7 +25,10 @@ def conectar(reintentos=3, espera=2):
     """
     for intento in range(1, reintentos + 1):
         try:
-            conn = pool.connection()
+            # ConnectionPool.connection() returns a context manager, which
+            # doesn't expose the cursor() method directly.  Use getconn()
+            # instead to obtain an actual connection object from the pool.
+            conn = pool.getconn()
             return conn
         except OperationalError as e:
             if intento < reintentos:


### PR DESCRIPTION
## Summary
- fix `conectar` to use `pool.getconn()` and return a real DB connection instead of a context manager

## Testing
- `python -m py_compile db.py`


------
https://chatgpt.com/codex/tasks/task_e_689b3632d198832da73a58340f9d9f48