### PR TITLE
Remove gzip compression from MessagePack requests

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -5,7 +5,7 @@ Este documento describe los endpoints expuestos por la aplicación Flask, junto 
 ## `views/upload.py`
 
 ### Funciones auxiliares
-- **`_get_json_gzip_aware()`**: Lee el cuerpo de la petición y, si viene comprimido con Gzip, lo descomprime antes de convertirlo a JSON.
+- **`_get_msgpack_payload()`**: Lee el cuerpo de la petición codificado en MessagePack.
 
 ### Endpoints
 - **`GET /`** y **`GET /cargar-pedidos`** (`upload_index`): muestra el formulario de carga de pedidos.

--- a/templates/generar_pedidos.html
+++ b/templates/generar_pedidos.html
@@ -103,7 +103,6 @@
 {# -------------------------- Dependencias JS ---------------------------- #}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/msgpack-lite@0.1.26/dist/msgpack.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
 
 {# --------------------------- Lógica cliente JS --------------------------- #}
 <script>
@@ -270,11 +269,10 @@ document.addEventListener('DOMContentLoaded', () => {
     /* --- POST y descarga ZIP --- */
     try{
       const packed = msgpack.encode(payload);
-      const gz = pako.gzip(packed);
       const res = await fetch('/generar-pedidos',{
         method:'POST',
-        headers:{'Content-Type':'application/msgpack','Content-Encoding':'gzip'},
-        body:gz
+        headers:{'Content-Type':'application/msgpack'},
+        body:packed
       });
       if(!res.ok){
         const err = await res.json().catch(()=>({error:`Error ${res.status}`}));

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -87,7 +87,6 @@
 
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/msgpack-lite@0.1.26/dist/msgpack.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
 <script>
   /* ---------------- Referencias DOM ---------------- */
   document.addEventListener('DOMContentLoaded', () => {
@@ -355,10 +354,9 @@ async function parseRutas(){
         /* ------ Enviar al backend y descargar resumen ------ */
         const encoder    = new TextEncoder();
         const packed = msgpack.encode({ pedidos: dataPed, rutas: rutasDia });
-        const gz = pako.gzip(packed);
         const res = await fetch(`/cargar-pedidos?dia=${encodeURIComponent(dia)}`, {
-          method:'POST', headers:{"Content-Encoding":"gzip","Content-Type":"application/msgpack"},
-          body:gz
+          method:'POST', headers:{"Content-Type":"application/msgpack"},
+          body:packed
         });
         if (!res.ok) { const err = await res.json().catch(() => ({error:`Error ${res.status}`})); throw new Error(err.error); }
         const blob = await res.blob();

--- a/views/generar_pedidos.py
+++ b/views/generar_pedidos.py
@@ -1,4 +1,4 @@
-import json, traceback, gzip
+import json, traceback
 from io import BytesIO
 import zipfile
 from datetime import datetime
@@ -12,10 +12,8 @@ from db import conectar
 generar_pedidos_bp = Blueprint("generar_pedidos", __name__, template_folder="../templates")
 
 
-def _get_msgpack_aware():
+def _get_msgpack_payload():
     raw = request.get_data()
-    if request.headers.get("Content-Encoding") == "gzip":
-        raw = gzip.decompress(raw)
     return msgpack.unpackb(raw, raw=False)
 
 @generar_pedidos_bp.route("/generar-pedidos", methods=["GET"])
@@ -29,7 +27,7 @@ def cargar_pedidos():
     try:
         # Datos enviados por el frontend (MessagePack)
         negocio = session.get("negocio"); empresa = session.get("empresa")
-        payload  = _get_msgpack_aware() or {}
+        payload  = _get_msgpack_payload() or {}
         data_inv = payload.get("inventario") or []
         data_mat = payload.get("materiales")
 

--- a/views/upload.py
+++ b/views/upload.py
@@ -1,4 +1,4 @@
-import gzip, json
+import json
 import msgpack
 from datetime import datetime
 from io import BytesIO
@@ -14,10 +14,8 @@ from views.auth import login_required
 upload_bp = Blueprint("upload", __name__, template_folder="../templates")
 
 
-def _get_json_gzip_aware():
+def _get_msgpack_payload():
     raw = request.get_data()
-    if request.headers.get("Content-Encoding") == "gzip":
-        raw = gzip.decompress(raw)
     return msgpack.unpackb(raw, raw=False)
 
 
@@ -32,8 +30,8 @@ def upload_index():
             with conectar() as conn:
                 with conn.cursor() as cur:
                     t0 = time.perf_counter()
-                    # ---- 1) JSON proveniente del frontend --------------------
-                    payload = _get_json_gzip_aware()
+                    # ---- 1) Datos MessagePack del frontend ------------------
+                    payload = _get_msgpack_payload()
                     pedidos = payload.get("pedidos", [])
                     rutas = payload.get("rutas")
                     p_dia = request.args.get("dia", "").strip()


### PR DESCRIPTION
## Summary
- parse MessagePack request bodies directly, dropping gzip handling in upload and generar_pedidos views
- adjust front-end forms to send raw MessagePack without gzip headers
- document new MessagePack-only helper in endpoint docs

## Testing
- `python -m py_compile views/upload.py views/generar_pedidos.py`


------
https://chatgpt.com/codex/tasks/task_e_689b8ec5b124832d9da11dda32480357