### PR TITLE
Add dynamic day option and bypass route filtering

### DIFF
--- a/MEMPRY FACT
+++ b/MEMPRY FACT
@@ -154,34 +154,49 @@ BEGIN
   WHERE x.tipo_pro   = 'N'
   AND x.estado = 'Sin Descargar' OR x.estado = 'Sin facturar';
   BEGIN
-  WITH cte AS (
-  SELECT
-    p_bd            AS bd,
-    (regexp_split_to_array(r.codigo_ruta, '[- ]'))[1]::INTEGER AS codigo_ruta,
-  (regexp_split_to_array(r.codigo_ruta, '[- ]'))[2]          AS dia,
-  (regexp_split_to_array(r.codigo_cliente, '[- ]'))[1]       AS codigo_cliente
-  FROM jsonb_to_recordset(p_rutas) AS r(
-    codigo_cliente TEXT,
-    codigo_ruta    TEXT
-  )
-)
-INSERT INTO rutas (bd, codigo_ruta, dia, codigo_cliente)
-SELECT bd, codigo_ruta, dia, codigo_cliente
-FROM cte
-WHERE dia = p_dia;
-
+    IF p_dia = 'dinamico' THEN
+      INSERT INTO rutas (bd, codigo_ruta, dia, codigo_cliente)
+      SELECT p_bd, r.codigo_ruta::INTEGER, p_dia, r.codigo_cliente
+      FROM jsonb_to_recordset(p_rutas) AS r(
+        codigo_cliente TEXT,
+        codigo_ruta    INTEGER
+      );
+    ELSE
+      WITH cte AS (
+        SELECT
+          p_bd            AS bd,
+          (regexp_split_to_array(r.codigo_ruta, '[- ]'))[1]::INTEGER AS codigo_ruta,
+          (regexp_split_to_array(r.codigo_ruta, '[- ]'))[2]          AS dia,
+          (regexp_split_to_array(r.codigo_cliente, '[- ]'))[1]       AS codigo_cliente
+        FROM jsonb_to_recordset(p_rutas) AS r(
+          codigo_cliente TEXT,
+          codigo_ruta    TEXT
+        )
+      )
+      INSERT INTO rutas (bd, codigo_ruta, dia, codigo_cliente)
+      SELECT bd, codigo_ruta, dia, codigo_cliente
+      FROM cte
+      WHERE dia = p_dia;
+    END IF;
 
   EXCEPTION
     WHEN unique_violation THEN
       RAISE EXCEPTION 'Un cliente no puede estar asignado a dos rutas en el mismo dia';
   END;
-  
 
-  UPDATE pedxclixprod p
-  SET ruta = r.codigo_ruta
-  FROM rutas r
-  WHERE p.codigo_cli   = r.codigo_cliente
-    AND r.dia           = p_dia;
+
+  IF p_dia = 'dinamico' THEN
+    UPDATE pedxclixprod p
+    SET ruta = r.codigo_ruta
+    FROM rutas r
+    WHERE p.codigo_cli = r.codigo_cliente;
+  ELSE
+    UPDATE pedxclixprod p
+    SET ruta = r.codigo_ruta
+    FROM rutas r
+    WHERE p.codigo_cli   = r.codigo_cliente
+      AND r.dia           = p_dia;
+  END IF;
 END;
 $$;
 -- VALIDACION DE PRODUCTOS BIG

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -59,6 +59,7 @@
           <option value="VI">Viernes (VI)</option>
           <option value="SA">Sábado (SA)</option>
           <option value="DO">Domingo (DO)</option>
+          <option value="dinamico">DINAMICO</option>
         </select>
       </div>
       <div>
@@ -100,7 +101,7 @@
   /* --------------- Definición de columnas ----------- */
     const PED_HEADERS = ["numero_pedido","cliente","nombre","barrio","ciudad","asesor","codigo_pro","producto","cantidad","valor","tipo_pro","estado"];
     const RUT_HEADERS = ["codigo_cliente","codigo_ruta"];
-    const DIAS_VALIDOS = ["LU","MA","MI","JU","VI","SA","DO"];
+    const DIAS_VALIDOS = ["LU","MA","MI","JU","VI","SA","DO","dinamico"];
 
      /* mapas sinónimos → canónico */
     const PED_COL_MAP = {
@@ -348,7 +349,9 @@ async function parseRutas(){
         await Promise.all([parsePedidos(), parseRutas()]);
         if(!dataPed || !dataRut) throw new Error('Archivos aún en procesamiento');
 
-        const rutasDia = dataRut.filter(r=>r.codigo_ruta && r.codigo_ruta.includes(dia));
+        const rutasDia = dia === 'dinamico'
+          ? dataRut
+          : dataRut.filter(r=>r.codigo_ruta && r.codigo_ruta.includes(dia));
         
         
         /* ------ Enviar al backend y descargar resumen ------ */


### PR DESCRIPTION
## Summary
- add `DINAMICO` option to day selector and support sending all routes without filtering
- extend stored procedure to handle `dinamico` day without splitting or filtering by day

## Testing
- `python -m py_compile app.py db.py views/upload.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2cc043e38832d83b3ec57867843e7