### PR TITLE
refactor: remove celluweb format from consolidar compras

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -35,7 +35,7 @@ Este documento describe los endpoints expuestos por la aplicación Flask, junto 
 - **`POST /consolidar-compras`** (`consolidar_compras_index`):
   1. Lee un Excel cargado por el usuario.
   2. Valida y agrupa columnas según `COLUMN_CONFIG`.
-  3. Genera un Excel consolidado para `celluweb` o `ecom` y opcionalmente un CSV adicional.
+  3. Genera un Excel consolidado para `ecom` y un CSV adicional.
   4. Guarda los archivos en un directorio temporal para su descarga posterior.
 - **`GET /consolidar-compras/download/<filename>`** (`descargar_archivo_file`): envía el archivo previamente generado.
 

--- a/templates/consolidar_compras.html
+++ b/templates/consolidar_compras.html
@@ -61,15 +61,6 @@
                       file:bg-purple-50 file:text-purple-700
                       hover:file:bg-purple-100">
       </div>
-      <div>
-        <label class="block mb-1 font-medium">🔀 Formato</label>
-        <select name="format" required
-                class="block w-full px-3 py-2 border rounded-lg">
-          <option value="">-- Elige formato --</option>
-          <option value="celluweb">Celuweb</option>
-          <option value="ecom">Ecom</option>
-        </select>
-      </div>
 
       <button type="submit"
               class="w-full py-3 font-semibold rounded-xl
@@ -80,23 +71,13 @@
 
     {% if download_filename %}
   <div id="download-section" class="mt-6 text-center space-y-2">
-    {# Si es lista, iteramos #}
-    {% if download_filename is iterable and download_filename is not string %}
       {% for fn in download_filename %}
         <a href="{{ url_for('consolidar_compras.descargar_archivo_file', filename=fn) }}"
-           
+
            class="inline-block px-6 py-3 bg-purple-600 text-white font-semibold rounded-xl hover:bg-purple-700">
           Descargar {{ fn.endswith('.csv') and 'CSV' or 'Excel' }}
         </a>
       {% endfor %}
-    {% else %}
-    {# Caso único (celluweb) #}
-      <a href="{{ url_for('consolidar_compras.descargar_archivo_file', filename=download_filename) }}"
-         onclick="document.getElementById('download-section').style.display = 'none';"
-         class="inline-block px-6 py-3 bg-purple-600 text-white font-semibold rounded-xl hover:bg-purple-700">
-        Descargar {{ download_filename.endswith('.csv') and 'CSV' or 'Excel' }}
-      </a>
-    {% endif %}
   </div>
 {% endif %}
 


### PR DESCRIPTION
## Summary
- drop celluweb option from consolidar compras form and view
- always process ecom format and generate accompanying CSV
- update endpoint docs accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c420edf958832da3d62aad474b2afa