### PR TITLE
Remove Celluweb instructions from HTML templates

### DIFF
--- a/templates/generar_pedidos.html
+++ b/templates/generar_pedidos.html
@@ -39,16 +39,6 @@
         </ol>
       </div>
 
-      <div>
-        <h3 class="flex items-center text-lg font-medium">
-          <span class="mr-2 text-purple-600">📦</span><span class="underline">CELUWEB</span>
-        </h3>
-        <ol class="list-decimal list-inside text-gray-700 ml-6 space-y-1">
-          {% if negocio != "nutresa" %}<li>Maestras → Materiales → Materiales → Buscar → Exportar</li>{% endif %}
-          <li>Inventarios → Informe inventarios → Inventario Total →  Mostrar inventario → Exportar</li>
-        </ol>
-      </div>
-
       <p class="mt-2 text-red-600 font-semibold">
         ⚠️ <span class="font-medium">IMPORTANTE:</span> Antes de este paso, en validaciones todos los clientes deben tener ruta asignada.
       </p>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -29,16 +29,6 @@
           <li>Despachos → ClixRuta</li>
         </ol>
       </div>
-      <div>
-        <h3 class="flex items-center text-lg font-medium">
-          <span class="mr-2 text-purple-600">📦</span>
-          <span class="underline">CELUWEB</span>
-        </h3>
-        <ol class="list-decimal list-inside text-gray-700 ml-6">
-          <li>Informes → Pedidos → Informe de pedidos por material</li>
-          <li>Logística → Facturación → Administración de Rutas → Asignación de Rutas → Exportar Rutas Asignadas</li>
-        </ol>
-      </div>
       <p class="text-red-600 font-semibold">
         ⚠️ <span class="font-medium">IMPORTANTE:</span> Antes de generar los pedidos, todos los clientes deben tener una ruta asignada.
       </p>


### PR DESCRIPTION
## Summary
- Remove Celluweb-specific instructions from bulk upload form
- Remove Celluweb-specific instructions from order generation form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c423699638832d8d8a4ec4d6db26e4