### PR TITLE
Allow custom purchase order number in consolidation

### DIFF
--- a/templates/consolidar_compras.html
+++ b/templates/consolidar_compras.html
@@ -62,6 +62,12 @@
                       hover:file:bg-purple-100">
       </div>
 
+      <div>
+        <label class="block mb-1 font-medium">📝 Orden de compra</label>
+        <input type="number" name="orden_compra" required
+               class="block w-full px-3 py-2 border rounded-xl" />
+      </div>
+
       <button type="submit"
               class="w-full py-3 font-semibold rounded-xl
                      bg-purple-600 text-white hover:bg-purple-700 transition">

--- a/views/consolidar_compras.py
+++ b/views/consolidar_compras.py
@@ -83,8 +83,12 @@ def consolidar_compras_index():
 
     if request.method == "POST":
         f = request.files.get("archivo")
+        orden_compra = request.form.get("orden_compra", "").strip()
         if not f:
             flash("Sube un Excel.", "error")
+            return redirect(url_for(".consolidar_compras_index"))
+        if not orden_compra.isdigit():
+            flash("Ingresa un número válido para la orden de compra.", "error")
             return redirect(url_for(".consolidar_compras_index"))
 
         try:
@@ -115,6 +119,8 @@ def consolidar_compras_index():
                 if cfg["action"] == "static":
                     agg[col] = cfg["static_value"]
 
+            agg["Orden de compra"] = orden_compra
+
             # --- Generar df_out y filename ---
             hoy = datetime.now().strftime("%Y%m%d")
             # cálculo Valor_neto
@@ -131,6 +137,7 @@ def consolidar_compras_index():
                 )
                 for new_col, spec in ECOM_COLUMN_SPEC.items()
             })[ECOM_COLUMNS]
+            df_out["Orden_de_compra"] = orden_compra
             filename = f"consolidado_ecom_{hoy}.xlsx"
 
             # --- Guardar Excel en buffer ---


### PR DESCRIPTION
## Summary
- Add input field for order number in Consolidar Compras form
- Pass user-provided order number through backend processing

## Testing
- `python -m py_compile views/consolidar_compras.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43b0253b4832d84d54a194caee834