### PR TITLE
Simplify consolidation to Excel download

### DIFF
--- a/templates/consolidar_compras.html
+++ b/templates/consolidar_compras.html
@@ -75,18 +75,6 @@
       </button>
     </form>
 
-    {% if download_filename %}
-  <div id="download-section" class="mt-6 text-center space-y-2">
-      {% for fn in download_filename %}
-        <a href="{{ url_for('consolidar_compras.descargar_archivo_file', filename=fn) }}"
-
-           class="inline-block px-6 py-3 bg-purple-600 text-white font-semibold rounded-xl hover:bg-purple-700">
-          Descargar {{ fn.endswith('.csv') and 'CSV' or 'Excel' }}
-        </a>
-      {% endfor %}
-  </div>
-{% endif %}
-
 
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Remove CSV generation and temporary file handling in purchase consolidation
- Return the consolidated Excel directly and drop download links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c46dfbd000832dba70b4fd411965c5