### PR TITLE
Fix spinner lingering after consolidar compras download

### DIFF
--- a/templates/consolidar_compras.html
+++ b/templates/consolidar_compras.html
@@ -84,14 +84,41 @@
     const form    = document.getElementById('cons-form');
     const overlay = document.getElementById('loading-overlay');
 
-    // Mostrar spinner al enviar
-    form.addEventListener('submit', () => {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
       overlay.classList.remove('hidden');
-    });
 
-    // Ocultar spinner tras recarga (errores o éxito)
-    window.addEventListener('load', () => {
-      overlay.classList.add('hidden');
+      try {
+        const formData = new FormData(form);
+        const res = await fetch(form.action, {
+          method: 'POST',
+          body: formData
+        });
+
+        const disposition = res.headers.get('Content-Disposition') || '';
+        if (disposition.includes('attachment')) {
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          const fn = disposition.match(/filename="?([^";]+)"?/i)?.[1] || `consolidado_${Date.now()}.xlsx`;
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = fn;
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
+        } else {
+          const html = await res.text();
+          document.open();
+          document.write(html);
+          document.close();
+        }
+      } catch (err) {
+        alert('Error al procesar la solicitud.');
+        console.error(err);
+      } finally {
+        overlay.classList.add('hidden');
+      }
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- Use `fetch` to submit consolidar-compras form and trigger file download
- Hide loading spinner once the request finishes or on errors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c47629230c832d8770d0f61beb4ab6