### PR TITLE
Evita spinner perpetuo y agrega acceso a Auditoría

### DIFF
--- a/templates/auditoria.html
+++ b/templates/auditoria.html
@@ -63,12 +63,34 @@
     const form = document.getElementById('export-form');
     const overlay = document.getElementById('loading-overlay');
 
-    form.addEventListener('submit', () => {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
       overlay.classList.remove('hidden');
-    });
 
-    window.addEventListener('load', () => {
-      overlay.classList.add('hidden');
+      try {
+        const response = await fetch(form.action, {
+          method: 'POST',
+          credentials: 'same-origin'
+        });
+
+        if (!response.ok) {
+          throw new Error('Error al descargar');
+        }
+
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'auditoria.xlsx';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        overlay.classList.add('hidden');
+      }
     });
   });
 </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,13 +36,20 @@
   </a>
 </li>
 <li class="flex items-center space-x-2">
-  <span class="w-6 h-6 flex items-center justify-center rounded-full 
+  <span class="w-6 h-6 flex items-center justify-center rounded-full
     {{ 'bg-blue-600 text-white' if request.endpoint=='consolidar_compras.consolidar_compras_index' else 'bg-gray-300 text-gray-700' }}">
     3
   </span>
   <a href="{{ url_for('consolidar_compras.consolidar_compras_index') }}"
      class="py-4 px-2 border-b-2 {{ 'border-blue-600 text-blue-600 font-semibold' if request.endpoint=='consolidar_compras.consolidar_compras_index' else 'border-transparent text-gray-700 hover:text-blue-600 hover:border-blue-600' }}">
     Consolidar Compras
+  </a>
+</li>
+
+<li>
+  <a href="{{ url_for('auditoria.auditoria_view') }}"
+     class="py-4 px-2 border-b-2 {{ 'border-blue-600 text-blue-600 font-semibold' if request.endpoint=='auditoria.auditoria_view' else 'border-transparent text-gray-700 hover:text-blue-600 hover:border-blue-600' }}">
+    Auditoría
   </a>
 </li>
 


### PR DESCRIPTION
## Summary
- Evita que el spinner de Auditoría quede activo tras descargar el Excel
- Agrega enlace a Auditoría en el menú principal sin numeración

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4d0b19a78832dbc367d930b241636