### PR TITLE
Include Pideky code in order summary

### DIFF
--- a/MEMPRY FACT
+++ b/MEMPRY FACT
@@ -70,10 +70,11 @@ CREATE TABLE PEDXCLIXPROD (
   asesor VARCHAR(20),
   codigo_pro VARCHAR(25),        
   producto VARCHAR(80),   
-  cantidad INTEGER,        
-  valor NUMERIC(14,2),   
-  tip_pro VARCHAR(2),        
-  estado VARCHAR(15)   
+  cantidad INTEGER,
+  valor NUMERIC(14,2),
+  tip_pro VARCHAR(2),
+  estado VARCHAR(15),
+  codigo_pideky TEXT
 );
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
@@ -110,7 +111,7 @@ BEGIN
     bd,
     numero_pedido,
     codigo_cli,
-    ruta,        
+    ruta,
     nombre,
     barrio,
     ciudad,
@@ -120,7 +121,8 @@ BEGIN
     cantidad,
     valor,
     tip_pro,
-    estado
+    estado,
+    codigo_pideky
   )
   SELECT
     p_bd,
@@ -136,9 +138,10 @@ BEGIN
     x.cantidad,
     x.valor,
     x.tipo_pro,
-    x.estado
+    x.estado,
+    x.codigo_pideky
   FROM jsonb_to_recordset(p_pedidos) AS x(
-    numero_pedido TEXT,    
+    numero_pedido TEXT,
     cliente       TEXT,
     nombre        TEXT,
     barrio        TEXT,
@@ -149,7 +152,8 @@ BEGIN
     cantidad      INTEGER,
     valor         NUMERIC,
     tipo_pro      TEXT,
-    estado        TEXT
+    estado        TEXT,
+    codigo_pideky TEXT
   )
   WHERE x.tipo_pro   = 'N'
   AND x.estado = 'Sin Descargar' OR x.estado = 'Sin facturar';
@@ -241,6 +245,7 @@ AS $$
       barrio,
       ciudad,
       asesor,
+      MAX(codigo_pideky) AS codigo_pideky,
       COUNT(DISTINCT numero_pedido) AS total_pedidos,
       SUM(valor) AS valor,
       ruta
@@ -249,7 +254,7 @@ AS $$
     GROUP BY
       barrio,
       codigo_cli,
-      bd,     
+      bd,
       nombre,
       ciudad,
       asesor,

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -89,7 +89,7 @@
     const flash   = document.getElementById('flash-messages');
     const form    = document.getElementById('upload-form');
   /* --------------- Definición de columnas ----------- */
-    const PED_HEADERS = ["numero_pedido","cliente","nombre","barrio","ciudad","asesor","codigo_pro","producto","cantidad","valor","tipo_pro","estado"];
+    const PED_HEADERS = ["numero_pedido","cliente","nombre","barrio","ciudad","asesor","codigo_pideky","codigo_pro","producto","cantidad","valor","tipo_pro","estado"];
     const RUT_HEADERS = ["codigo_cliente","codigo_ruta"];
     const DIAS_VALIDOS = ["LU","MA","MI","JU","VI","SA","DO","dinamico"];
 
@@ -105,6 +105,8 @@
       'Ciudad':'ciudad',
       'Asesor':'asesor',
       'codVendedor':'asesor',
+      'Codigo Pideky':'codigo_pideky',
+      'Código Pideky':'codigo_pideky',
       'Cod.Prod':'codigo_pro',
       'codProducto':'codigo_pro',
       'Producto':'producto',
@@ -195,7 +197,11 @@
       // Copio todas las columnas excepto tipo_pro
       normHead.forEach((hdr, i) => {
         if (PED_HEADERS.includes(hdr) && hdr !== 'tipo_pro') {
-          o[hdr] = vals[i];
+          let val = vals[i];
+          if (hdr === 'codigo_pideky' && val != null) {
+            val = String(val);
+          }
+          o[hdr] = val;
         }
       });
       // Inyecto tipo_pro según corresponda

--- a/views/upload.py
+++ b/views/upload.py
@@ -51,8 +51,20 @@ def upload_index():
 
             # ---- 3) Obtener resumen en JSON --------------------------
             data_res = json.loads(raw) if isinstance(raw, str) else (raw or [])
-            cols = ["bd", "codigo_cli", "nombre", "barrio", "ciudad", "asesor", "total_pedidos", "valor", "ruta"]
+            cols = [
+                "bd",
+                "codigo_cli",
+                "nombre",
+                "barrio",
+                "ciudad",
+                "asesor",
+                "codigo_pideky",
+                "total_pedidos",
+                "valor",
+                "ruta",
+            ]
             df_res = pd.DataFrame(data_res, columns=cols)
+            df_res["codigo_pideky"] = df_res["codigo_pideky"].astype(str)
 
             # ---- 4) Exportar a Excel
             buf = BytesIO()


### PR DESCRIPTION
## Summary
- Treat `codigo_pideky` as text in `pedxclixprod` and ETL processing
- Export `codigo_pideky` as string in the order summary
- Parse and send `codigo_pideky` from the upload form

## Testing
- `python -m py_compile views/upload.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4d7131b88832d82e402a2b63099ac