### PR TITLE
Remove dynamic option from day filtering

### DIFF
--- a/MEMPRY FACT
+++ b/MEMPRY FACT
@@ -158,30 +158,21 @@ BEGIN
   WHERE x.tipo_pro   = 'N'
   AND x.estado = 'Sin Descargar' OR x.estado = 'Sin facturar';
   BEGIN
-    IF p_dia = 'dinamico' THEN
-      INSERT INTO rutas (bd, codigo_ruta, dia, codigo_cliente)
-      SELECT p_bd, r.codigo_ruta::INTEGER, p_dia, r.codigo_cliente
+    WITH cte AS (
+      SELECT
+        p_bd            AS bd,
+        (regexp_split_to_array(r.codigo_ruta, '[- ]'))[1]::INTEGER AS codigo_ruta,
+        (regexp_split_to_array(r.codigo_ruta, '[- ]'))[2]          AS dia,
+        (regexp_split_to_array(r.codigo_cliente, '[- ]'))[1]       AS codigo_cliente
       FROM jsonb_to_recordset(p_rutas) AS r(
         codigo_cliente TEXT,
-        codigo_ruta    INTEGER
-      );
-    ELSE
-      WITH cte AS (
-        SELECT
-          p_bd            AS bd,
-          (regexp_split_to_array(r.codigo_ruta, '[- ]'))[1]::INTEGER AS codigo_ruta,
-          (regexp_split_to_array(r.codigo_ruta, '[- ]'))[2]          AS dia,
-          (regexp_split_to_array(r.codigo_cliente, '[- ]'))[1]       AS codigo_cliente
-        FROM jsonb_to_recordset(p_rutas) AS r(
-          codigo_cliente TEXT,
-          codigo_ruta    TEXT
-        )
+        codigo_ruta    TEXT
       )
-      INSERT INTO rutas (bd, codigo_ruta, dia, codigo_cliente)
-      SELECT bd, codigo_ruta, dia, codigo_cliente
-      FROM cte
-      WHERE dia = p_dia;
-    END IF;
+    )
+    INSERT INTO rutas (bd, codigo_ruta, dia, codigo_cliente)
+    SELECT bd, codigo_ruta, dia, codigo_cliente
+    FROM cte
+    WHERE dia = p_dia;
 
   EXCEPTION
     WHEN unique_violation THEN
@@ -189,18 +180,11 @@ BEGIN
   END;
 
 
-  IF p_dia = 'dinamico' THEN
-    UPDATE pedxclixprod p
-    SET ruta = r.codigo_ruta
-    FROM rutas r
-    WHERE p.codigo_cli = r.codigo_cliente;
-  ELSE
-    UPDATE pedxclixprod p
-    SET ruta = r.codigo_ruta
-    FROM rutas r
-    WHERE p.codigo_cli   = r.codigo_cliente
-      AND r.dia           = p_dia;
-  END IF;
+  UPDATE pedxclixprod p
+  SET ruta = r.codigo_ruta
+  FROM rutas r
+  WHERE p.codigo_cli   = r.codigo_cliente
+    AND r.dia           = p_dia;
 END;
 $$;
 -- VALIDACION DE PRODUCTOS BIG

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -49,7 +49,6 @@
           <option value="VI">Viernes (VI)</option>
           <option value="SA">Sábado (SA)</option>
           <option value="DO">Domingo (DO)</option>
-          <option value="dinamico">DINAMICO</option>
         </select>
       </div>
       <div>
@@ -91,7 +90,7 @@
   /* --------------- Definición de columnas ----------- */
     const PED_HEADERS = ["numero_pedido","cliente","nombre","barrio","ciudad","asesor","codigo_pideky","codigo_pro","producto","cantidad","valor","tipo_pro","estado"];
     const RUT_HEADERS = ["codigo_cliente","codigo_ruta"];
-    const DIAS_VALIDOS = ["LU","MA","MI","JU","VI","SA","DO","dinamico"];
+      const DIAS_VALIDOS = ["LU","MA","MI","JU","VI","SA","DO"];
 
      /* mapas sinónimos → canónico */
     const PED_COL_MAP = {
@@ -345,9 +344,7 @@ async function parseRutas(){
         await Promise.all([parsePedidos(), parseRutas()]);
         if(!dataPed || !dataRut) throw new Error('Archivos aún en procesamiento');
 
-        const rutasDia = dia === 'dinamico'
-          ? dataRut
-          : dataRut.filter(r=>r.codigo_ruta && r.codigo_ruta.includes(dia));
+          const rutasDia = dataRut.filter(r=>r.codigo_ruta && r.codigo_ruta.includes(dia));
         
         
         /* ------ Enviar al backend y descargar resumen ------ */


### PR DESCRIPTION
## Summary
- drop 'dinamico' option from upload day selector and script
- simplify SQL procedure to handle only specific weekdays

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4f0d50a4c832dacee1c0f8272016b