### PR TITLE
Add inventory distribution label on generate orders page

### DIFF
--- a/templates/generar_pedidos.html
+++ b/templates/generar_pedidos.html
@@ -23,7 +23,8 @@
   </div>
 
   <div class="max-w-lg mx-auto bg-white p-8 rounded-3xl shadow-xl space-y-6">
-    <div class="flex justify-end space-x-2">
+    <div class="flex justify-end items-center space-x-2">
+      <span class="text-sm font-medium">REPARTIR INVENTARIO SOLO EN:</span>
       <input type="number" name="carro1" min="0" placeholder="O1"
              class="w-16 px-2 py-1 border rounded text-sm" />
       <input type="number" name="carro2" min="0" placeholder="O2"


### PR DESCRIPTION
## Summary
- Display "REPARTIR INVENTARIO SOLO EN:" to the left of O1/O2 inputs on the Generar Pedidos page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c51347366c832da9a7aeb7f0d65d74